### PR TITLE
Add iscsid handler

### DIFF
--- a/roles/iscsi_devices/handlers/main.yml
+++ b/roles/iscsi_devices/handlers/main.yml
@@ -6,6 +6,12 @@
     state: restarted
     enabled: true
 
+- name: Restart iscsid daemon
+  ansible.builtin.systemd:
+    name: iscsid
+    state: restarted
+    enabled: true
+
 - name: Replay kernel device events
   ansible.builtin.command:
     cmd: "{{ item }}"

--- a/roles/iscsi_devices/tasks/multipath.yml
+++ b/roles/iscsi_devices/tasks/multipath.yml
@@ -12,6 +12,7 @@
     multipath_devices: "{{ iscsi_devices_config | selectattr('multipath') | list }}"
   notify:
     - Restart multipath daemon
+    - Restart iscsid daemon
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
This change ensures that the `iscsid` service is enabled in order to persist devices across system reboots in addition to restarting the service after system configuration changes.