### PR TITLE
Prevent Vault secret leakage in Ansible logs

### DIFF
--- a/roles/informix_db/tasks/main.yml
+++ b/roles/informix_db/tasks/main.yml
@@ -51,6 +51,7 @@
 - name: Retrieve Informix configuration from Hashicorp Vault
   ansible.builtin.set_fact:
     informix_vault_config: "{{ lookup('community.hashi_vault.hashi_vault', informix_db_vault_path) | default('') }}"
+  no_log: true
 
 - name: Provision server instance
   ansible.builtin.include_tasks: server.yml

--- a/roles/informix_management/tasks/main.yml
+++ b/roles/informix_management/tasks/main.yml
@@ -17,11 +17,13 @@
 - name: Retrieve alerts config from Hashicorp Vault
   ansible.builtin.set_fact:
     informix_management_alerts_config: "{{ lookup('community.hashi_vault.hashi_vault', informix_management_alerts_vault_path) }}"
+  no_log: true
   when: informix_management_alerts_enabled
 
 - name: Retrieve stats config from Hashicorp Vault
   ansible.builtin.set_fact:
     informix_management_stats_config: "{{ lookup('community.hashi_vault.hashi_vault', informix_management_stats_vault_path) }}"
+  no_log: true
   when: informix_management_stats_enabled
 
 - name: Create scripts directory

--- a/roles/iscsi_devices/tasks/main.yml
+++ b/roles/iscsi_devices/tasks/main.yml
@@ -16,6 +16,7 @@
 - name: Retrieve iSCSI device config from Hashicorp Vault
   ansible.builtin.set_fact:
     iscsi_devices_vault_config: "{{ lookup('community.hashi_vault.hashi_vault', iscsi_devices_vault_path) }}"
+  no_log: true
 
 - name: Check iSCSI device WWIDs are present in Hashicorp Vault
   ansible.builtin.assert:


### PR DESCRIPTION
This update prevents sensitive data retrieved from HashiCorp Vault from being exposed when verbose logging or debugging is enabled.

Previously, Vault-derived values were assigned to facts, with log suppression applied only to subsequent tasks that consumed those facts. This change adds `no_log: true` to the tasks retrieving the secrets themselves, providing an additional safeguard against accidental exposure.

Resolves: `CWE-532`.