### PR TITLE
Validate `informix_db_server_name` to prevent unsafe `become_user` usage

### DIFF
--- a/roles/informix_db/tasks/main.yml
+++ b/roles/informix_db/tasks/main.yml
@@ -10,6 +10,12 @@
       - informix_db_vault_path is defined and informix_db_vault_path | trim | length > 0
     msg: "Required variable(s) empty or undefined"
 
+- name: Ensure informix_db_server_name is a valid informix_db_config key
+  ansible.builtin.assert:
+    that:
+      - informix_db_server_name in informix_db_config
+    fail_msg: "informix_db_server_name must be one of: {{ informix_db_config.keys() | list }}"
+
 - name: Create isql symbolic link
   ansible.builtin.file:
     src: "{{ informix_db_install_path }}/bin/dbaccess"

--- a/roles/informix_db/tasks/main.yml
+++ b/roles/informix_db/tasks/main.yml
@@ -16,6 +16,14 @@
       - informix_db_server_name in informix_db_config
     fail_msg: "informix_db_server_name must be one of: {{ informix_db_config.keys() | list }}"
 
+- name: Ensure informix_db_server_name is not a privileged user
+  ansible.builtin.assert:
+    that:
+      - informix_db_server_name not in informix_db_server_name_deny_list
+    fail_msg: "informix_db_server_name must not be one of: {{ informix_db_server_name_deny_list }}"
+  vars:
+    informix_db_server_name_deny_list: ['root', 'bin', 'daemon', 'informix']
+
 - name: Create isql symbolic link
   ansible.builtin.file:
     src: "{{ informix_db_install_path }}/bin/dbaccess"


### PR DESCRIPTION
This update adds input validation for the `informix_db_server_name` variable to:

- Prevent accidental or unsafe use of privileged accounts when using `become_user`
- Reduce risk of configuration errors leading to privilege boundary violations

Resolves: `CWE-20`.